### PR TITLE
#72&#73/tasks s01 04&05 - Flight and Leg entities

### DIFF
--- a/src/main/java/acme/entities/flights/Flight.java
+++ b/src/main/java/acme/entities/flights/Flight.java
@@ -15,6 +15,7 @@ import acme.client.components.validation.Mandatory;
 import acme.client.components.validation.Optional;
 import acme.client.components.validation.ValidMoney;
 import acme.client.components.validation.ValidString;
+import acme.realms.AirlineManager;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/acme/entities/flights/Flight.java
+++ b/src/main/java/acme/entities/flights/Flight.java
@@ -1,0 +1,91 @@
+
+package acme.entities.flights;
+
+import java.util.Date;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Transient;
+import javax.validation.Valid;
+
+import acme.client.components.basis.AbstractEntity;
+import acme.client.components.datatypes.Money;
+import acme.client.components.mappings.Automapped;
+import acme.client.components.validation.Mandatory;
+import acme.client.components.validation.Optional;
+import acme.client.components.validation.ValidMoney;
+import acme.client.components.validation.ValidString;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Flight extends AbstractEntity {
+
+	// Serialisation version --------------------------------------------------
+
+	private static final long	serialVersionUID	= 1L;
+
+	// Attributes -------------------------------------------------------------
+
+	@Mandatory
+	@ValidString(min = 1, max = 50)
+	private String				tag;
+
+	@Mandatory
+	@Automapped
+	private boolean				selfTransfer;
+
+	@Mandatory
+	@ValidMoney
+	@Automapped
+	private Money				cost;
+
+	@Optional
+	@ValidString
+	@Automapped
+	private String				description;
+
+	// Derived attributes -----------------------------------------------------
+
+
+	@Transient
+	public Date getScheduledDeparture() {
+		//TO DO IN D03
+		return null;
+	}
+
+	@Transient
+	public Date getScheduledArrival() {
+		//TO DO IN D03
+		return null;
+	}
+
+	@Transient
+	public String getOriginCity() {
+		//TO DO IN D03
+		return null;
+	}
+
+	@Transient
+	public String getDestinationCity() {
+		//TO DO IN D03
+		return null;
+	}
+
+	@Transient
+	public int getNumberOfLayovers() {
+		//TO DO IN D03
+		return 0;
+	}
+
+	// Relationships ----------------------------------------------------------
+
+
+	@Mandatory
+	@Valid
+	@ManyToOne
+	private AirlineManager airlineManager;
+
+}

--- a/src/main/java/acme/entities/flights/Flight.java
+++ b/src/main/java/acme/entities/flights/Flight.java
@@ -4,7 +4,7 @@ package acme.entities.flights;
 import java.util.Date;
 
 import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 import javax.validation.Valid;
 
@@ -86,7 +86,7 @@ public class Flight extends AbstractEntity {
 
 	@Mandatory
 	@Valid
-	@ManyToOne
+	@OneToOne(optional = false)
 	private AirlineManager airlineManager;
 
 }

--- a/src/main/java/acme/entities/flights/Leg.java
+++ b/src/main/java/acme/entities/flights/Leg.java
@@ -4,17 +4,25 @@ package acme.entities.flights;
 import java.util.Date;
 
 import javax.persistence.Column;
+import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.Valid;
 
+import acme.client.components.basis.AbstractEntity;
 import acme.client.components.validation.Mandatory;
 import acme.client.components.validation.ValidMoment;
 import acme.client.components.validation.ValidNumber;
 import acme.client.components.validation.ValidString;
+import acme.entities.airports.Airport;
+import lombok.Getter;
+import lombok.Setter;
 
-public class Leg {
+@Entity
+@Getter
+@Setter
+public class Leg extends AbstractEntity {
 
 	// Serialisation version --------------------------------------------------
 
@@ -58,10 +66,10 @@ public class Leg {
 	private Airport				arrivalAirport;
 
 	// El Aircraft asignado, que pertenece a una Airline, de la cual se extrae el código IATA.
-	@Mandatory
-	@ManyToOne(optional = false)
-	@Valid
-	private Aircraft			aircraft;
+	//@Mandatory
+	//@ManyToOne(optional = false)
+	//@Valid
+	//private Aircraft			aircraft;
 
 	@Mandatory
 	@ManyToOne(optional = false)

--- a/src/main/java/acme/entities/flights/Leg.java
+++ b/src/main/java/acme/entities/flights/Leg.java
@@ -1,0 +1,71 @@
+
+package acme.entities.flights;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.validation.Valid;
+
+import acme.client.components.validation.Mandatory;
+import acme.client.components.validation.ValidMoment;
+import acme.client.components.validation.ValidNumber;
+import acme.client.components.validation.ValidString;
+
+public class Leg {
+
+	// Serialisation version --------------------------------------------------
+
+	private static final long	serialVersionUID	= 1L;
+
+	// Attributes -------------------------------------------------------------
+
+	// Preguntar sobre este atributo. Debería ser derivado para poder obtener el IATA de la aerolínea?
+	@Column(unique = true)
+	@Mandatory
+	@ValidString(pattern = "^[A-Z]{3}\\d{4}$")
+	private String				flightNumber;
+
+	@Mandatory
+	@ValidMoment(past = true)
+	@Temporal(TemporalType.TIMESTAMP)
+	private Date				scheduledDeparture;
+
+	@Mandatory
+	@ValidMoment(past = true)
+	private Date				scheduledArrival;
+
+	@Mandatory
+	@ValidNumber(min = 0, integer = 2, fraction = 0)
+	private Double				durationInHours;
+
+	@Mandatory
+	@Valid
+	private LegStatus			status;
+
+	// Relationships ----------------------------------------------------------
+
+	@Mandatory
+	@ManyToOne(optional = false)
+	@Valid
+	private Airport				departureAirport;
+
+	@Mandatory
+	@ManyToOne(optional = false)
+	@Valid
+	private Airport				arrivalAirport;
+
+	// El Aircraft asignado, que pertenece a una Airline, de la cual se extrae el código IATA.
+	@Mandatory
+	@ManyToOne(optional = false)
+	@Valid
+	private Aircraft			aircraft;
+
+	@Mandatory
+	@ManyToOne(optional = false)
+	@Valid
+	private Flight				flight;
+
+}

--- a/src/main/java/acme/entities/flights/LegStatus.java
+++ b/src/main/java/acme/entities/flights/LegStatus.java
@@ -1,0 +1,8 @@
+
+package acme.entities.flights;
+
+public enum LegStatus {
+
+	ON_TIME, DELAYED, CANCELLED, LANDED
+
+}


### PR DESCRIPTION
This pull request introduces new entities for managing flights and their details in the system. The most important changes include the creation of the `Flight` and `Leg` entities, along with the `LegStatus` enumeration.

New entities and enumeration:

* [`src/main/java/acme/entities/flights/Flight.java`](diffhunk://#diff-637a1bd6fbbc084e62a65cf7030ef1d93329f3eff54dc159502357a30c616966R1-R92): Added a new `Flight` entity with attributes such as `tag`, `selfTransfer`, `cost`, and `description`. It also includes derived attributes like `getScheduledDeparture`, `getScheduledArrival`, `getOriginCity`, `getDestinationCity`, and `getNumberOfLayovers`. The entity is related to `AirlineManager`.

* [`src/main/java/acme/entities/flights/Leg.java`](diffhunk://#diff-66dec629d233ade6c3ed6c52ba46c6e7022e298a6a38d531b80ae59b9d762b3eR1-R79): Added a new `Leg` entity with attributes such as `flightNumber`, `scheduledDeparture`, `scheduledArrival`, `durationInHours`, and `status`. The entity is related to `Airport` for both departure and arrival, and to `Flight`.

* [`src/main/java/acme/entities/flights/LegStatus.java`](diffhunk://#diff-1a6ee3f32c30eb7ce7cea1771d7873a46cbcaedefb61d544f1a698ddf378187dR1-R8): Added a new enumeration `LegStatus` with possible values `ON_TIME`, `DELAYED`, `CANCELLED`, and `LANDED`.