### PR TITLE
feat: Aircraft Entity

### DIFF
--- a/src/main/java/acme/entities/aircraft/Aircraft.java
+++ b/src/main/java/acme/entities/aircraft/Aircraft.java
@@ -1,0 +1,48 @@
+
+package acme.entities.aircraft;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import org.hibernate.validator.constraints.Length;
+
+import acme.client.components.basis.AbstractEntity;
+import acme.client.components.validation.Mandatory;
+import acme.client.components.validation.Optional;
+import acme.client.components.validation.ValidNumber;
+import acme.client.components.validation.ValidString;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Aircraft extends AbstractEntity {
+
+	private static final long	serialVersionUID	= 1L;
+
+	@Mandatory
+	@Length(max = 50)
+	protected String			model;
+
+	@Mandatory
+	@Column(unique = true)
+	@Length(max = 50)
+	protected String			registrationNumber;
+
+	@Mandatory
+	@ValidNumber(min = 0)
+	protected Integer			capacity;
+
+	@Mandatory
+	@ValidNumber(min = 2, max = 50)
+	protected Integer			cargoWeight;
+
+	@Mandatory
+	protected ServiceStatus		status;
+
+	@Optional
+	@ValidString
+	protected String			details;
+
+}

--- a/src/main/java/acme/entities/aircraft/ServiceStatus.java
+++ b/src/main/java/acme/entities/aircraft/ServiceStatus.java
@@ -1,0 +1,7 @@
+
+package acme.entities.aircraft;
+
+public enum ServiceStatus {
+	ACTIVE, MAINTENANCE
+
+}


### PR DESCRIPTION
This pull request introduces a new `Aircraft` entity and a corresponding `ServiceStatus` enumeration to the `acme.entities.aircraft` package. These changes define the structure and validation rules for the `Aircraft` entity, which includes several mandatory fields with specific constraints.

New entity and enumeration:

* [`src/main/java/acme/entities/aircraft/Aircraft.java`](diffhunk://#diff-29a233723ea065da000f99bcbf6b34a3c2ce185f6de3fd9611ba0ff70f991887R1-R48): Added a new `Aircraft` entity class with fields for `model`, `registrationNumber`, `capacity`, `cargoWeight`, `status`, and `details`. Each field includes validation annotations to enforce constraints.
* [`src/main/java/acme/entities/aircraft/ServiceStatus.java`](diffhunk://#diff-3732f265dab81ba029d236700a2289bd9c451d691336caf8a968bfb90873a16fR1-R7): Added a new `ServiceStatus` enumeration with values `ACTIVE` and `MAINTENANCE` to represent the status of an aircraft.