### PR TITLE
#71/task s01 03

### DIFF
--- a/src/main/java/acme/constraints/ManagerValidator.java
+++ b/src/main/java/acme/constraints/ManagerValidator.java
@@ -1,0 +1,70 @@
+
+package acme.constraints;
+
+import javax.validation.ConstraintValidatorContext;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.principals.DefaultUserIdentity;
+import acme.client.components.validation.AbstractValidator;
+import acme.features.authenticated.manager.AuthenticatedManagerRepository;
+import acme.realms.Manager;
+
+public class ManagerValidator extends AbstractValidator<ValidManager, Manager> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AuthenticatedManagerRepository repository;
+
+
+	@Override
+	protected void initialise(final ValidManager annotation) {
+		assert annotation != null;
+	}
+
+	@Override
+	public boolean isValid(final Manager manager, final ConstraintValidatorContext context) {
+		assert context != null;
+
+		boolean result;
+
+		if (manager == null)
+			super.state(context, false, "*", "javax.validation.constraints.NotNull.message");
+		else {
+			{
+				// Validar que el identifier cumple con el patrón "^[A-Z]{2,3}\d{6}$"
+				String identifier = manager.getIdentifier();
+				boolean matchesPattern = identifier != null && identifier.matches("^[A-Z]{2,3}\\d{6}$");
+				super.state(context, matchesPattern, "identifier", "acme.validation.manager.invalid-identifier.message");
+			}
+			{
+				// Validar que el identifier sea único
+				Manager existingManager = this.repository.findManagerByIdentifier(manager.getIdentifier());
+				boolean uniqueIdentifier = existingManager == null || existingManager.equals(manager);
+				super.state(context, uniqueIdentifier, "identifier", "acme.validation.manager.duplicated-identifier.message");
+			}
+			{
+				// Validar que las dos primeras letras del identifier coinciden con las iniciales de la identidad.
+				String identifier = manager.getIdentifier();
+				DefaultUserIdentity identity = manager.getIdentity();
+				if (identifier != null && identity != null && identifier.length() >= 2) {
+					String name = identity.getName();
+					String surname = identity.getSurname();
+					// Se valida que la primera letra de identifier coincide con la del name,
+					// y la segunda letra de identifier coincide con la del surname.
+					boolean initialsValid = false;
+					if (name != null && surname != null && !name.isEmpty() && !surname.isEmpty()) {
+						char initialName = name.charAt(0);
+						char initialSurname = surname.charAt(0);
+						initialsValid = identifier.charAt(0) == initialName && identifier.charAt(1) == initialSurname;
+					}
+					super.state(context, initialsValid, "identifier", "acme.validation.manager.incorrect-initials.message");
+				}
+			}
+		}
+
+		result = !super.hasErrors(context);
+		return result;
+	}
+}

--- a/src/main/java/acme/constraints/ValidManager.java
+++ b/src/main/java/acme/constraints/ValidManager.java
@@ -1,0 +1,23 @@
+
+package acme.constraints;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ManagerValidator.class)
+public @interface ValidManager {
+
+	// Standard validation properties -----------------------------------------
+	String message() default "";
+
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/acme/entities/flights/Flight.java
+++ b/src/main/java/acme/entities/flights/Flight.java
@@ -15,7 +15,7 @@ import acme.client.components.validation.Mandatory;
 import acme.client.components.validation.Optional;
 import acme.client.components.validation.ValidMoney;
 import acme.client.components.validation.ValidString;
-import acme.realms.AirlineManager;
+import acme.realms.Manager;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -88,6 +88,6 @@ public class Flight extends AbstractEntity {
 	@Mandatory
 	@Valid
 	@OneToOne(optional = false)
-	private AirlineManager airlineManager;
+	private Manager airlineManager;
 
 }

--- a/src/main/java/acme/features/authenticated/manager/AuthenticatedManagerRepository.java
+++ b/src/main/java/acme/features/authenticated/manager/AuthenticatedManagerRepository.java
@@ -1,0 +1,15 @@
+
+package acme.features.authenticated.manager;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import acme.client.repositories.AbstractRepository;
+import acme.realms.Manager;
+
+@Repository
+public interface AuthenticatedManagerRepository extends AbstractRepository {
+
+	@Query("select m from Manager m where m.identifier = :identifier")
+	Manager findManagerByIdentifier(String identifier);
+}

--- a/src/main/java/acme/realms/AirlineManager.java
+++ b/src/main/java/acme/realms/AirlineManager.java
@@ -36,7 +36,7 @@ public class AirlineManager extends AbstractRole {
 	private String				identifier;
 
 	@Mandatory
-	@ValidNumber(min = 0, integer = 2, fraction = 0) //TODO: Definir máximo. preguntar en el foro
+	@ValidNumber(min = 0, max = 75, integer = 2, fraction = 0)
 	@Automapped
 	private Integer				yearsOfExperience;
 

--- a/src/main/java/acme/realms/Manager.java
+++ b/src/main/java/acme/realms/Manager.java
@@ -16,13 +16,15 @@ import acme.client.components.validation.ValidMoment;
 import acme.client.components.validation.ValidNumber;
 import acme.client.components.validation.ValidString;
 import acme.client.components.validation.ValidUrl;
+import acme.constraints.ValidManager;
 import lombok.Getter;
 import lombok.Setter;
 
 @Entity
 @Getter
 @Setter
-public class AirlineManager extends AbstractRole {
+@ValidManager
+public class Manager extends AbstractRole {
 
 	// Serialisation version --------------------------------------------------
 
@@ -31,12 +33,12 @@ public class AirlineManager extends AbstractRole {
 	// Attributes -------------------------------------------------------------
 
 	@Mandatory
-	@ValidString(pattern = "^[A-Z]{2,3}\\d{6}$")
+	@ValidString(pattern = "^[A-Z]{2,3}\\d{6}$") //Custom Validator
 	@Column(unique = true)
 	private String				identifier;
 
 	@Mandatory
-	@ValidNumber(min = 0, max = 75, integer = 2, fraction = 0)
+	@ValidNumber(min = 0, max = 120)
 	@Automapped
 	private Integer				yearsOfExperience;
 

--- a/src/main/resources/WEB-INF/views/validation-en.i18n
+++ b/src/main/resources/WEB-INF/views/validation-en.i18n
@@ -1,0 +1,3 @@
+acme.validation.manager.invalid-identifier.message = Invalid identifier format. It must consist of 2 or 3 uppercase letters followed by 6 digits.
+acme.validation.manager.duplicated-identifier.message = Duplicate identifier. This identifier is already used by another manager.
+acme.validation.manager.incorrect-initials.message = The first two letters of the identifier must match the initials of the manager's name and surname.

--- a/src/main/resources/WEB-INF/views/validation-es.i18n
+++ b/src/main/resources/WEB-INF/views/validation-es.i18n
@@ -1,0 +1,3 @@
+acme.validation.manager.invalid-identifier.message = Formato de identificador inválido. Debe consistir en 2 o 3 letras mayúsculas seguidas de 6 dígitos.
+acme.validation.manager.duplicated-identifier.message = Identificador duplicado. Este identificador ya está siendo utilizado por otro manager.
+acme.validation.manager.incorrect-initials.message = Las dos primeras letras del identificador deben coincidir con las iniciales del nombre y del apellido del manager.


### PR DESCRIPTION
This pull request introduces a new validation mechanism for the `Manager` entity, replaces the `AirlineManager` entity with `Manager`, and updates related files accordingly. The most important changes include the creation of a custom validator for the `Manager` entity, the renaming of the `AirlineManager` class, and the addition of new validation messages in both English and Spanish.

### Manager validation:
* [`src/main/java/acme/constraints/ManagerValidator.java`](diffhunk://#diff-273db15a5aaff5f8a6a5f430c111306576972d7ca0f5006e5e4e389613c0e1beR1-R70): Added a custom validator to ensure the identifier follows a specific pattern, is unique, and matches the initials of the manager's name and surname.
* [`src/main/java/acme/constraints/ValidManager.java`](diffhunk://#diff-05975232e6ebe351647d3b9f5440bebc8d44ee7484cd1236845b08cd3d3167ffR1-R23): Created a new annotation for validating `Manager` entities.

### Entity renaming:
* [`src/main/java/acme/realms/Manager.java`](diffhunk://#diff-99c8c34f1409ddb4db583ed0e711f9cfd2f5edd117085b8dce7c140ef32dcf05R19-R27): Renamed from `AirlineManager` and annotated with `@ValidManager` to apply the custom validation. [[1]](diffhunk://#diff-99c8c34f1409ddb4db583ed0e711f9cfd2f5edd117085b8dce7c140ef32dcf05R19-R27) [[2]](diffhunk://#diff-99c8c34f1409ddb4db583ed0e711f9cfd2f5edd117085b8dce7c140ef32dcf05L34-R41)
* [`src/main/java/acme/entities/flights/Flight.java`](diffhunk://#diff-637a1bd6fbbc084e62a65cf7030ef1d93329f3eff54dc159502357a30c616966L18-R18): Replaced `AirlineManager` with `Manager` in the `Flight` entity. [[1]](diffhunk://#diff-637a1bd6fbbc084e62a65cf7030ef1d93329f3eff54dc159502357a30c616966L18-R18) [[2]](diffhunk://#diff-637a1bd6fbbc084e62a65cf7030ef1d93329f3eff54dc159502357a30c616966L91-R91)

### Repository updates:
* [`src/main/java/acme/features/authenticated/manager/AuthenticatedManagerRepository.java`](diffhunk://#diff-122490c45234b5d155250d1263d55f062a9114c625153f7df94da5db020e8702R1-R15): Added a repository interface for managing `Manager` entities, including a query to find a manager by identifier.

### Internationalization:
* [`src/main/resources/WEB-INF/views/validation-en.i18n`](diffhunk://#diff-4299ffab4dfa70bd1d05c5f29d73731df5fb184136a63eb06e99a3170119fde7R1-R3): Added new validation messages in English for the `Manager` entity.
* [`src/main/resources/WEB-INF/views/validation-es.i18n`](diffhunk://#diff-cae3d3d4f8bdd3813b6bc38c2de0704b481f3d3d6fca97e1afeb03b137e4bff9R1-R3): Added new validation messages in Spanish for the `Manager` entity.